### PR TITLE
Updated workdir for update script

### DIFF
--- a/update-site.sh
+++ b/update-site.sh
@@ -1,3 +1,5 @@
+cd /storage/webtree/redbrick/main-site
+
 git fetch -a
 
 git pull -r


### PR DESCRIPTION
The script in its previous state assumed that the cron tab would execute it in the site directory. This change just changes the directory in the update script to ensure its run in the site directory.